### PR TITLE
Bug/message board showing when shouldnt

### DIFF
--- a/lib/components/search_field_button.dart
+++ b/lib/components/search_field_button.dart
@@ -10,8 +10,7 @@ class SearchFieldButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return FlatButton(
-      padding: EdgeInsets.fromLTRB(8.0, 4.0, 8.0, 0),
+    return TextButton(
       child: Column(
         children: <Widget>[
           Padding(

--- a/lib/components/search_field_button.dart
+++ b/lib/components/search_field_button.dart
@@ -11,7 +11,7 @@ class SearchFieldButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return FlatButton(
-      padding: EdgeInsets.all(16.0),
+      padding: EdgeInsets.fromLTRB(8.0, 4.0, 8.0, 0),
       child: Column(
         children: <Widget>[
           Padding(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      debugShowCheckedModeBanner: false,
       title: 'Manchester Metro Trams',
       theme: ThemeData(
         primaryColor: Color(kPrimaryColour),

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -77,14 +77,16 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
   void showInSnackBar(String value) {
     _scaffoldKey.currentState.showSnackBar(new SnackBar(
       content: new Text(value),
-      duration: Duration(seconds: 10),
+      duration: Duration(seconds: 5),
     ));
   }
 
   @override
   Widget build(BuildContext context) {
-    var showMessageBoardIcon =
-        stationPlatforms != null && stationPlatforms[0].messageBoard.length > 0;
+    var showMessageBoardIcon = stationPlatforms != null &&
+        stationPlatforms[0].messageBoard.length > 0 &&
+        stationPlatforms[0].messageBoard !=
+            "<no message>"; // Bug in the manchester API showing this
 
     return Scaffold(
       backgroundColor: Color(kBackgroundColour),

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -23,7 +23,6 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
   String stationLocation = "Manchester Airport";
   List<Station> stationPlatforms;
   Timer timer;
-  final GlobalKey<ScaffoldState> _scaffoldKey = new GlobalKey<ScaffoldState>();
 
   @override
   void initState() {
@@ -75,7 +74,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
   }
 
   void showInSnackBar(String value) {
-    _scaffoldKey.currentState.showSnackBar(new SnackBar(
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
       content: new Text(value),
       duration: Duration(seconds: 5),
     ));
@@ -101,7 +100,6 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
               ]
             : null,
       ),
-      key: _scaffoldKey,
       body: RefreshIndicator(
         onRefresh: getLatestStationData,
         child: Column(

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -38,6 +38,8 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
 
   @override
   void dispose() {
+    timer.cancel();
+
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
   }


### PR DESCRIPTION
- Fixes a potential memory leak
- Bandages over the manchester metrolink API, as they're showing <no message> sometimes when there's no message
- Fixes warnings as some widgets are depreciated